### PR TITLE
Test-All and Test-Any filters methods dont work with pester

### DIFF
--- a/functional.psm1
+++ b/functional.psm1
@@ -240,7 +240,7 @@ filter Test-All {
   end {
     foreach($result in $results){
       if(-not $result){
-        return false
+        return $false
       }
     }
     return $true

--- a/functional.psm1
+++ b/functional.psm1
@@ -230,16 +230,20 @@ Returns true if all elements in the pipeline are truthy
 filter Test-All {
   [OutputType([boolean])]
   Param()
-
-  process {
-    if (-not $_) {
-      $false
-      break
-    }
+  
+  begin {
+    $results = @()
   }
-
+  process {
+    $results += $_
+  }
   end {
-    $true
+    foreach($result in $results){
+      if(-not $result){
+        return false
+      }
+    }
+    return $true
   }
 }
 
@@ -252,15 +256,26 @@ filter Test-Any {
   [OutputType([boolean])]
   Param()
 
-  process {
-    if ($_) {
-      $true
-      break
-    }
+  begin {
+    $results = @()
   }
-
+  process {
+    $results += $_
+  }
   end {
-    $false
+    # foreach($result in $results){
+    #   if($result -isnot [bool] -and $result -isnot [int]){
+    #     return false
+    #   }
+    # }
+    # return ($results -contains $true) 
+    foreach($result in $results){
+      if((-not $result) -eq $false){
+        return $true
+      }
+    }
+    #return ($results -contains $true) 
+    return $false
   }
 }
 

--- a/functional.tests.ps1
+++ b/functional.tests.ps1
@@ -278,4 +278,11 @@ Describe "Test-Equality" {
       @{a = 1; b = @{c = 2 } }, @{a = 1; b = @{c = 2 } } | Test-Equality | Should -BeTrue
     }
   }
+  Context "Given an array of PSCustomObject" {
+    $a = @([PSCustomObject]@{ 'Name' = 'Foo'; 'Value' = 'Foo' }, [PSCustomObject]@{ 'Name' = 'Baz'; 'Value' = 'Baz'  } )
+    $b = @([PSCustomObject]@{ 'Name' = 'xxx'; 'Value' = 'Foo' }, [PSCustomObject]@{ 'Name' = 'Baz'; 'Value' = 'Baz'  } )
+    It "Should be false for deep inequal values" {      
+      $a, $b | Test-Equality | Should -BeFalse
+    }
+  }
 }


### PR DESCRIPTION
The break statement in the Test-All and Test-Any filter methods was forcing the Pester Should code to exit early. This is a known issue in Pester. [https://github.com/pester/Pester/issues/289](url)

The following tests highlight the existing problem. Each test, tests for both true and false output. However all the tests pass. This should not be the case, only one test in each given block should pass, either the output is truthy or it is not.

```
Import-Module Pester -DisableNameChecking -Force
Import-Module Functional -DisableNameChecking -Force

Describe "Test-Equality" {
  Context "Given leaves" {
    $a = '3'
    $b = 3

    It "Should be false for equal values of different types" {
      $a, $b | Test-Equality | Should -BeFalse
    }
    It "Should be false for equal values of different types but is not" {
      $a, $b | Test-Equality | Should -BeTrue
    }
  }
  Context "Given arrays" {
    $a = @(1, 2, @{a = 1 }, 3)
    $b = @(1, 2, @{a = 2 }, 3)
    It "Should be false for deep inequal values" {
      $a, $b | Test-Equality | Should -BeFalse
    }
    It "Should be false for deep inequal values but is not" {
      $a, $b | Test-Equality | Should -BeTrue
    }
  }
  Context "Given hashtables" {
    $a = @{a = 1; b = @{c = 2 } }
    $b = @{a = 1; b = [pscustomobject]@{c = 2 } }
    It "Should be false for deep inequal values" {
      $a, $b | Test-Equality | Should -BeFalse
    }
    It "Should be false for deep inequal values but is not" {
      $a, $b | Test-Equality | Should -BeTrue
    }
  }

  Context "Given an array of PSCustomObject" {
    $a = @([PSCustomObject]@{ 'Name' = 'Foo'; 'Value' = 'Foo' }, [PSCustomObject]@{ 'Name' = 'Baz'; 'Value' = 'Baz'  } )
    $b = @([PSCustomObject]@{ 'Name' = 'xxx'; 'Value' = 'Foo' }, [PSCustomObject]@{ 'Name' = 'Baz'; 'Value' = 'Baz'  } )
    It "Should be false for deep inequal values" {      
      $a, $b | Test-Equality | Should -BeFalse
    }
    It "Should be false for deep inequal values but is not" {
      $a, $b | Test-Equality | Should -BeTrue
    }
  }
}
```