### PR TITLE
Added initial, aka seed, value (-InitValue) parameter to Reduce-Object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vscode
+.vs

--- a/functional.psm1
+++ b/functional.psm1
@@ -186,7 +186,8 @@ function Reduce-Object {
     [ValidateNotNullOrEmpty()]
     [object[]] $Object,
     [ParamStyle] $ParamStyle = "Infer",
-    [Direction] $Direction = "Right"
+    [Direction] $Direction = "Right",
+    [Object] $InitValue = $null
   )
 
   # deduce and validate scriptblock invokation style
@@ -202,10 +203,19 @@ function Reduce-Object {
     [array]::Reverse($input)
   }
 
+  # set up init value. if not given indirectly, otherwise directly
+  if ($null -eq $InitValue)
+  {
+    $accum = $input | Select -First 1 ;
+    $skip = 1
+  } else {
+    $accum = $InitValue;
+    $skip = 0
+  }
+
   # invoke the reducer
-  $accum = $input | Select -First 1
   if ($implicit) {
-    foreach ($object in $input | Select -Skip 1) {
+    foreach ($object in $input | Select -Skip $skip) {
       # invoke in scriptblock to minimize exposure of local variables
       $safelyScoped = {
         Param($a, $b, [scriptblock]$reducer)
@@ -215,7 +225,7 @@ function Reduce-Object {
     }
   }
   if ($explicit) {
-    foreach ($object in $input | Select -Skip 1) {
+    foreach ($object in $input | Select -Skip $skip) {
       $accum = &$Reducer $accum $object
     }
   }

--- a/functional.tests.ps1
+++ b/functional.tests.ps1
@@ -52,6 +52,16 @@ Describe "Reduce-Object" {
       $reduced | Should -Be $measured
     }
   }
+  Context "Given an explicit initial value should use that" {
+    It "Should sum up the numbers with initial value" {
+      $initValue = 30
+      $values = 1..10
+      $reducer = { Param($a, $b); $a + $b }
+      $reduced = $values | Reduce-Object $reducer -InitValue $initValue
+      $measured = $initValue + ($values | Measure-Object -Sum | % Sum)
+      $reduced | Should -Be $measured
+    }
+  }
 }
 
 Describe "Merge-Object" {


### PR DESCRIPTION
Per suggestion on Medium, I added an initial (or seed) value parameter to the Reduce-Object function (parameter name is -InitValue).

This is useful in multiple piping steps to avoid having to find a way to insert the inti value midstream.

Instead of this:
`$values = Step1 | Step2 | Step3`
`$result = @($init) + $values | Reduce-Object $accumulator`


We can do this:
`
$result = Step1 | Step2 | Step3 | Reduce-Object $accumulator -InitValue $init
`

Added unit test as well.
Thx
